### PR TITLE
Add present state to devices

### DIFF
--- a/Sources/FritzBoxKit.swift
+++ b/Sources/FritzBoxKit.swift
@@ -108,6 +108,11 @@ open class FritzBox: NSObject {
         load(authentication) { result in
 
             if case .success(let sessionInfo) = result {
+                guard sessionInfo.sid != "0000000000000000" else {
+                    // username or password is invalid
+                    completion(.failure(AuthError.invalidCredendials))
+                    return
+                }
                 // Save session ID for later use.
                 self.sessionId = sessionInfo.sid
                 self.sessionIdReceived = Date()

--- a/Sources/Model/SmartHomeDevice.swift
+++ b/Sources/Model/SmartHomeDevice.swift
@@ -54,6 +54,7 @@ extension FritzBox {
         public var identifier: String = ""
         public var features: Feature = []
         public var manufacturer: String = ""
+        public var present: Bool = false
         public var productName: String = ""
         public var displayName: String = ""
         
@@ -73,6 +74,7 @@ extension FritzBox {
             identifier      <- map.attributes["identifier"]
             manufacturer    <- map.attributes["manufacturer"]
             productName     <- map.attributes["productname"]
+            present         <- map["present"]
             displayName     <- map["name"]
             
             temperature     <- map["temperature"]

--- a/Tests/Fritz_Box_KitTests.swift
+++ b/Tests/Fritz_Box_KitTests.swift
@@ -53,6 +53,7 @@ class MappingTests: XCTestCase {
             
             switch index {
             case 1: // Radiator regulator.
+                XCTAssertEqual(device.present, true, "Present state should match.")
                 XCTAssertEqual(device.displayName, "Kinderzimmer", "Display name should match.")
                 XCTAssertEqual(device.temperature?.celsius, 22, "Temp. should match.")
                 XCTAssertEqual(device.temperature?.offset, 0, "Temp. should match.")
@@ -69,6 +70,7 @@ class MappingTests: XCTestCase {
                 XCTAssertEqual(device.hkr?.batteryLow, true, "Value should match.")
                 
             case 2: // Radiator regulator.
+                XCTAssertEqual(device.present, true, "Present state should match.")
                 XCTAssertEqual(device.displayName, "Küche", "Display name should match.")
                 XCTAssertEqual(device.temperature?.celsius, 23, "Temp. should match.")
                 XCTAssertEqual(device.temperature?.offset, 0, "Temp. should match.")
@@ -85,6 +87,7 @@ class MappingTests: XCTestCase {
                 XCTAssertEqual(device.hkr?.batteryLow, false, "Value should match.")
                 
             case 3: // Power switch.
+                XCTAssertEqual(device.present, true, "Present state should match.")
                 XCTAssertEqual(device.productName, "FRITZ!DECT 200", "Product name should match.")
                 XCTAssertEqual(device.displayName, "Steckdose", "Display name should match.")
                 XCTAssertEqual(device.features, [.temperatureSensor, .powerSwitch, .energySensor], "Features should match")
@@ -101,6 +104,7 @@ class MappingTests: XCTestCase {
                 XCTAssertEqual(device.powerMeter?.energy, 5.419, "Energy should match")
                 
             default: // First element in the list.
+                XCTAssertEqual(device.present, true, "Present state should match.")
                 XCTAssertEqual(device.displayName, "Wohnzimmer", "Display name should match.")
                 XCTAssertEqual(device.temperature?.celsius, 24.5, "Temp. should match.")
                 XCTAssertEqual(device.temperature?.offset, -20, "Temp. should match.")


### PR DESCRIPTION
Add present state to devices, e.g. to distinguish whether switch is plugged in or not